### PR TITLE
Use ESP32 RTC time to set and extract datetime

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,6 +63,7 @@ lib_deps =
 	; https://github.com/arduino-libraries/SD.git
 	; https://github.com/CodeForAfrica/sensors.AFRICA-Adafruit_FONA.git
 	bblanchon/ArduinoJson @ ^7.4.1
+	fbiego/ESP32Time@^2.0.6
 
 monitor_filters = esp32_exception_decoder
 


### PR DESCRIPTION
# Description
Using  ESP internal real-time clock tracking reduces the time to query the current time, unlike querying the GSM network clock time for example; the GSM network time query feature has been observed to be "buggy" when the response is not sent in the expected time.
GSM network time is used to set the RTC at boot. 

## What's new?
1. Use ESP32 Time Library.
2. Struct to store datetime, epoch timestamp and timezone.

## Type of change
1. New feature (Non-breaking)

## Checklist
- [x] Firmware compiled without errors and/or warnings.
- [x] Firmware tested on a device and gave expected 
