### PR TITLE
Captive portal with DNS

### DIFF
--- a/data/config.html
+++ b/data/config.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -181,6 +181,17 @@
         display: flex;
         gap: 12px;
       }
+      .skip-btn {
+        display: block;
+        margin: 50px auto;
+        background: #e23602;
+        border: none;
+        border-radius: 6px;
+        color: #fff;
+        padding: 0.8rem 2rem;
+        font-size: 1.2em;
+        cursor: pointer;
+      }
     </style>
   </head>
   <body onload="loadDeviceSettings()">
@@ -263,6 +274,7 @@
         </div>
       </form>
     </div>
+    <button class="skip-btn" onclick="skipConfig()">Skip device config</button>
     <script>
       let currentStep = 0;
       function showStep(idx) {
@@ -369,6 +381,16 @@
         let el = document.getElementById("hotspot-" + ssid);
         if (el) el.classList.add("selected");
         document.getElementById("ssid").value = ssid;
+      }
+
+      function skipConfig() {
+        fetch("/config?skip=true")
+          .then((response) => response.text())
+          .then((text) => {
+            console.log(text);
+            window.location.href = "/";
+          })
+          .catch((e) => console.error("Error skipping config: ", e));
       }
     </script>
   </body>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,7 @@
 size_t max_wifi_hotspots_size = sizeof(struct_wifiInfo) * 20;
 struct struct_wifiInfo *wifiInfo = (struct_wifiInfo *)malloc(max_wifi_hotspots_size);
 uint8_t count_wifiInfo;
+bool isCaptivePortalViewed = false;
 
 DHTNEW dht(ONEWIRE_PIN);                           // DHT sensor, pin, type
 SerialPM pms(PMS5003, PM_SERIAL_RX, PM_SERIAL_TX); // PMSx003, RX, TX
@@ -204,13 +205,17 @@ void setup()
     else
     {
         Serial.println("LittleFS mounted successfully");
+        // ToDo: refactor webserver and dns setup after loading device configs
         WiFi.softAP(AP_SSID, AP_PWD);
         unsigned time_for_wifi_config = 600000;
         Serial.print("struct_wifiInfo* wifiInfo size: ");
         Serial.println(max_wifi_hotspots_size);
 
         wifi_networks_scan(wifiInfo, count_wifiInfo);
+        // DNS server for captive portal
+        dnsServer.start(DNS_PORT, "*", WiFi.softAPIP());
         setup_webserver();
+        startCaptivePortal(isCaptivePortalViewed);
 
         // 10 minutes timeout for wifi config
         // unsigned long last_page_load = millis();

--- a/src/utils/wifi.h
+++ b/src/utils/wifi.h
@@ -18,6 +18,7 @@ extern uint8_t count_wifiInfo;
 
 static const IPAddress AP_IP(192, 168, 4, 1);
 static DNSServer dnsServer;
+#define DNS_PORT 53
 
 // extern bool wificonfig_loop;
 
@@ -214,6 +215,16 @@ static void connectWifi(const char *WLANSSID, const char *WLANPWD)
         // WiFi.softAP(cfg::fs_ssid, cfg::fs_pwd, selectChannelForAp());
         wifiAPbegin(WLANSSID, WLANPWD);
     }
+}
+
+static void startCaptivePortal(bool &isCaptivePortalViewed)
+{
+
+    while (!isCaptivePortalViewed)
+    {
+        dnsServer.processNextRequest();
+    }
+    dnsServer.stop();
 }
 
 #endif


### PR DESCRIPTION
Simple captive portal implementation with DNS: redirect all requests to the `config` page, and allow skipping device configuration which stops the DNS.
